### PR TITLE
.vscode: add common-sense settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "editor.rulers": [
+        80,
+        120
+    ],
+    "editor.detectIndentation": false,
+    "files.insertFinalNewline": true,
+    "files.associations": {
+        "Makefile.*": "makefile",
+        "*.mk": "makefile"
+    },
+    "[shellscript][c][cpp]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true,
+    },
+    "[makefile]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+    },
+}


### PR DESCRIPTION
vscode has a tendency to mess up indent and terminating new lines, unless explicitly told to not mess things up. This adds a minimal vs code config telling it to not mess up things.